### PR TITLE
Fix typo and semantics

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
         <meta name="keywords" lang="en" content="refugees, app, jugendhackt, germany, help">
         <meta name="keywords" lang="de" content="flüchtlinge, app, webseite, deutschland, hilfe, jugendhackt">
         <meta name="theme-color" content="#003171">
-        
+
         <title>Germany Says Welcome</title>
 
         <link rel="stylesheet" href="third-party/css/bootstrap.min.css">
@@ -194,7 +194,7 @@
         <aside class="bg-dark">
             <div class="container text-center">
                 <div class="call-to-action">
-                    <h2 data-i18n="index:GitHub">Check out our GitHub Repository!</h2>
+                    <h2 data-i18n="index:GitHub">Check out our GitHub Repositories!</h2>
                     <a href="https://github.com/socialc0de" class="btn btn-default btn-xl wow tada" data-i18n="SourceCode">Source Code</a>
                 </div>
             </div>

--- a/locales/de/index.json
+++ b/locales/de/index.json
@@ -22,7 +22,7 @@
     "HowItAllBegan": "Wie alles begann",
     "Press": "Press",
     "ArticleJuHa": "Artikel über Jugend Hackt",
-    "GitHub": "Schau dir unsere GitHub Repository an!",
+    "GitHub": "Schau dir unsere GitHub Repositories an!",
     "SourceCode": "Source Code",
     "LetsGoTouch": "Komm mit uns in Kontakt!",
     "LetsGoTouch-Text": "Wir freuen uns sehr, wenn Sie mit uns in Kontakt treten wollen. Kontaktieren Sie uns per Mail, Telefon oder über die sozialen Medien:",

--- a/locales/en/index.json
+++ b/locales/en/index.json
@@ -22,7 +22,7 @@
     "HowItAllBegan": "How it all began",
     "Press": "Press",
     "ArticleJuHa": "Article about JugendHackt",
-    "GitHub": "Check out our GitHub Repository!",
+    "GitHub": "Check out our GitHub Repositories!",
     "SourceCode": "Source Code",
     "LetsGoTouch": "Let's Get In Touch!",
     "LetsGoTouch-Text": "Do you want to get in touch with us to help improving our software? That's great! Contact us via mail, phone or social media:",


### PR DESCRIPTION
In der deutschen Version stand "Schau dir unsere Github Repository an", ist hierdurch gefixt. Repository wurde in der deutschen und englischen Version durch den Plural ersetzt, da es sich ja nicht nur um eins, sondern mehrere handelt.
